### PR TITLE
set a different api key for local development.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -37,7 +37,14 @@
 
   <!-- segment.io -->
   <script type="text/javascript">!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
-    analytics.load("oYxl7b92cjkh5Et7feoBTtVp4jfknzS2");
+    
+
+    {% if jekyll.environment == "production" %}
+      analytics.load("oYxl7b92cjkh5Et7feoBTtVp4jfknzS2");
+    {% else %}
+      analytics.load("xPBgNdEqIFZmifgwFwMcvMNaHMLrIJhB");
+    {% endif %}
+    
     analytics.page({%if page.analytics_category %}'{{ page.analytics_category }}', {% endif %}{% if page.title %}'{{ page.title }}'{% endif %})
   }}();
   </script>


### PR DESCRIPTION
Hi!

I've added a switch in the head.html to ensure we only set the live api key when published to github.io, to prevent any events caused in development are not stored in the segment.io dashboard. (homepage project). We now have a new project (homepage-local-development) and a different write key. 

The jekyll.environment is set to true by github pages as seen here: http://mikeljames.github.io/
see changes: https://github.com/mikeljames/mikeljames.github.io/commit/d73f6b13a1e758b851728d623e2382ed7b530937

I used a personal github pages to test this out. 
