### PR TITLE
fix(blog) add missing protocol handler to URL

### DIFF
--- a/_posts/2015-09-22-audio-hackday-pocket-operators.md
+++ b/_posts/2015-09-22-audio-hackday-pocket-operators.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Audio HackDay - Pocket Operator
 author: Martin Schinz
-categories: 
+categories:
   - hack day
 ---
 
@@ -46,5 +46,3 @@ John said that he really enjoyed learning about the [Reactive Extensions](https:
 ## Link to source
 
 You can find the source for this project on [github](https://github.com/pebblecode/pocketOperator).
-
-

--- a/_posts/2015-12-08-christmas-slack-o-meter.md
+++ b/_posts/2015-12-08-christmas-slack-o-meter.md
@@ -46,7 +46,7 @@ The team consisted of Aisling, fashioning the front-end, Clorama, hacking on the
 
 ![API diagram](/img/posts/2015-12-08-christmas-slack-o-meter/cristmas-meter-diagram.png)
 
-For the API I used [Hapi](hapijs.com), a rich API framework that we've used for Hacks before. I wanted to use this Hackathon to familiarise myself with its structure, and I found it great - a quickly assembled springboard to launch our application from. For persistence we used [MongoDB](https://www.mongodb.org/) and to simplify DB connections and schema we used [Mongoose](http://mongoosejs.com/), both of which play nicely with Hapi.
+For the API I used [Hapi](http://hapijs.com), a rich API framework that we've used for Hacks before. I wanted to use this Hackathon to familiarise myself with its structure, and I found it great - a quickly assembled springboard to launch our application from. For persistence we used [MongoDB](https://www.mongodb.org/) and to simplify DB connections and schema we used [Mongoose](http://mongoosejs.com/), both of which play nicely with Hapi.
 
 But the hardware was still giving us a headache. After much deliberating and some eating of humble Pi we decided to scale back our ambitions and instead focus on the Live Demo, since 5pm had somehow leapt on us out of nowhere, like an Australian dropbear.
 


### PR DESCRIPTION
- Add missing protocol handler to URL (to make it work).
- Clean up whitespace.
