### PR TITLE
[fix] update for Jekyll 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 2.5.3'
-
+gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 2.5.3)
+  jekyll-paginate
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -33,3 +33,4 @@ defaults:
     values:
       analytics_category: "blog"
 
+gems: [jekyll-paginate]


### PR DESCRIPTION
Github Pages now runs on Jekyll 3.0
