### PR TITLE
Add related posts to verticals and careers page

### DIFF
--- a/4-careers.md
+++ b/4-careers.md
@@ -2,6 +2,7 @@
 layout: careers
 title: careers
 permalink: /careers/
+categories: [hacks]
 group: nav
 colour: purple
 

--- a/_includes/blog-related.html
+++ b/_includes/blog-related.html
@@ -1,39 +1,29 @@
 <aside class="related-container">
   <h3 class="related-title grid">Related Posts</h3>
   <ul class="related-posts grid">
-
   {% assign pstCnt = 0 %}
-
   {% for pcategory in page.categories %}
-
     {% assign pcatrep = pcategory | replace: ' ', '-' %}
-
     {% for post in site.posts %}
-
       {% for category in post.categories %}
-
-          {% assign preCat = category | replace: ' ', '-' %}
-          {% assign newCat = preCat | downcase %}
-
-          {% if post.url != page.url %}
-            {% if newCat == pcatrep limit:3 %}
-
-              {% if pstCnt < 3 %}
-
-                {% include blog-related-post.html %}
-                {% assign noblogposts = false %}
-
-                {% assign pstCnt = pstCnt | plus: 1 %}
-
-                {% endif %}
-
+        {% assign preCat = category | replace: ' ', '-' %}
+        {% assign newCat = preCat | downcase %}
+        {% if post.url != page.url %}
+          {% if newCat == pcatrep limit:3 %}
+            {% if pstCnt < 3 %}
+              {% include blog-related-post.html %}
+              {% assign noblogposts = false %}
+              {% assign pstCnt = pstCnt | plus: 1 %}
             {% endif %}
           {% endif %}
-
+          <!-- if newCat == pcatrep limit:3 -->
+        {% endif %}
+        <!-- /if post.url != page.url -->
       {% endfor %}
-
+      <!-- /category in post.categories -->
     {% endfor %}
-
+    <!-- for post in site.posts -->
   {% endfor %}
+  <!-- for pcategory in page.categories -->
   </ul>
 </aside>

--- a/_layouts/careers.html
+++ b/_layouts/careers.html
@@ -63,6 +63,8 @@
 
     {% include recruitee.html %}
 
+    {% include blog-related.html %}
+    
     {% include footer.html %}
     <!-- /scripts-->
 

--- a/_layouts/vertical.html
+++ b/_layouts/vertical.html
@@ -72,10 +72,6 @@
       {% include vert-section.html %}
     {% endfor %}
 
-
-
-
-
     <section id="" class="vert-section-container">
       <div class="vert-section-inner grid vert-section-contact ">
         <h2 class="vert-section-title">Sound interesting?</h2>
@@ -88,6 +84,9 @@
         </div>
       </div>
     </section>
+
+    {% include blog-related.html %}
+    
     {% include footer.html extrascripts=page.extrascripts lazyload=true %}
   </body>
 </html>

--- a/_sass/components/_related.scss
+++ b/_sass/components/_related.scss
@@ -19,11 +19,29 @@
     background-color: lighten($ink, 50);
     transform: rotate(1.2deg) scale(1.2);
   }
+
+  .vertical & {
+    background-color: #da4975;
+    margin-top: 0;
+
+    &::before { background-color: #da4975; }
+    .related-post-item::before { box-shadow: 0 0 10px 0 rgba(black, 0.2); }
+
+    .related-title {
+      color: white;
+      padding: 0 20px 20px;
+      text-shadow: 2px 2px 0 rgba(black, 0.2);
+
+      @media screen and ( max-width: $medium + 250px ) {
+        padding: 0 0 20px;
+      }
+    }
+  }
 }
 
 .related-title {
   font-size: $beta - 2px;
-  padding: 0 40px 30px;
+  padding: 0 40px 20px;
   position: relative;
   z-index: 1;
 
@@ -54,7 +72,7 @@
     left: 0;
     background-color: white;
     box-shadow: 0 0 10px 0 rgba(black, 0.1);
-    transform: rotate(-0.6deg);
+    transform: scale(1.02) rotate(-0.6deg);
   }
 
   &:not(:nth-child(-n+3)) { display: none; }
@@ -70,11 +88,11 @@
   }
 
   &:nth-child(2)::before {
-    transform: rotate(0.3deg);
+    transform: scale(1.02) rotate(0.3deg);
   }
 
   &:nth-child(3)::before {
-    transform: rotate(-0.7deg);
+    transform: scale(1.02) rotate(-0.7deg);
   }
 
   .btn {

--- a/_sass/pages/_vertical.scss
+++ b/_sass/pages/_vertical.scss
@@ -369,11 +369,7 @@ a.vert-insur-cta-link {
 
 
   &:nth-last-of-type(2) {
-    &:before {}
-
-    &:after {
-       background-color: $pink;
-    }
+    &:after { background-color: $pink; }
   }
 
   &:last-of-type {

--- a/vertical-health.md
+++ b/vertical-health.md
@@ -1,6 +1,7 @@
 ---
 layout: vertical
 title: Health
+categories: [health]
 permalink: /health/
 colour: aqua
 
@@ -81,4 +82,3 @@ sections:
 ---
 
 This renders as content
-

--- a/vertical-insurance.md
+++ b/vertical-insurance.md
@@ -2,6 +2,7 @@
 layout: vertical
 title: Insurance
 permalink: /insurance/
+categories: [innovation, insurance]
 colour: blue
 extraclasses: insurance
 extrascripts:
@@ -54,4 +55,3 @@ insurance-paragraphs:
 ---
 
 This renders as content
-

--- a/vertical-transport.md
+++ b/vertical-transport.md
@@ -2,6 +2,7 @@
 layout: vertical
 title: Transport
 permalink: /transport/
+categories: [transport]
 group:
 colour: blue
 
@@ -48,4 +49,3 @@ sections:
 ---
 
 This renders as content
-


### PR DESCRIPTION
Added the related posts component (same used for blog posts) to each verticals page and the careers page.

Categories uses to show related posts:
**Transport:** transport
**Insurance:** innovation, insurance
**Health:** health
**Careers:** hacks
